### PR TITLE
Fix compile error due to `unsafePerformIO`

### DIFF
--- a/Graphics/X11/Xlib/Image.hs
+++ b/Graphics/X11/Xlib/Image.hs
@@ -25,11 +25,10 @@ module Graphics.X11.Xlib.Image(
 import Graphics.X11.Types
 import Graphics.X11.Xlib.Types
 
-import Foreign
--- import Foreign.C
+import Foreign (Ptr, throwIfNull)
 import Foreign.C.Types
 
-import System.IO.Unsafe
+import System.IO.Unsafe (unsafePerformIO)
 
 ----------------------------------------------------------------
 -- Image


### PR DESCRIPTION
This breakage was introduced in f9054bd8da05085f8822b206399e0a3f5bc49548
and affects GHC 7.2 through GHC 7.6